### PR TITLE
Moved `pytz` package to `install_requires`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setuptools.setup(
     long_description="Monufacture is a factory framework with an API designed to make " +
                      "it as easy as possible to generate valid test data in MongoDB. " +
                      "Inspired by the excellent factory_girl Ruby Gem.",
-    install_requires=['pymongo'],
-    tests_require=['mock', 'nose', 'freezegun', 'pytz']
+    install_requires=['pymongo', 'pytz'],
+    tests_require=['mock', 'nose', 'freezegun']
 )


### PR DESCRIPTION
`pytz` package is used in the helpers module.
That's why it has to be listed as one of the main dependencies.

Thanks.
