### PR TITLE
Upgrade PyMongo to >=3, bump our version to 2.0.0

### DIFF
--- a/monufacture/factory.py
+++ b/monufacture/factory.py
@@ -97,7 +97,7 @@ class Factory(object):
             raise IOError("Cannot create an instance when no collection is provided.")
 
         doc = self.build(name_, **overrides)
-        doc_id = self.collection.insert(doc, safe=True)
+        doc_id = self.collection.insert(doc)
         self.created_ids.append(doc_id)
         return self.collection.find_one(doc_id)
 
@@ -105,7 +105,7 @@ class Factory(object):
     def cleanup(self):
         """Cleanup all instances created by this factory."""
         while len(self.created_ids) > 0:
-            self.collection.remove(self.created_ids.pop(), safe=True)
+            self.collection.remove(self.created_ids.pop())
 
     def default(self, attrs, traits=[]):
         """Sets the default document dict for the factory."""

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setuptools.setup(
     long_description="Monufacture is a factory framework with an API designed to make " +
                      "it as easy as possible to generate valid test data in MongoDB. " +
                      "Inspired by the excellent factory_girl Ruby Gem.",
-    install_requires=['pymongo>=3.0.0', 'pytz'],
+    install_requires=['pymongo>=3.0.0,<4.0.0', 'pytz'],
     tests_require=['mock', 'nose', 'freezegun']
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="Monufacture",
-    version="1.0.0",
+    version="2.0.0",
     author="Tom Leach",
     author_email="tom@gc.io",
     description="A lightweight factory framework for easily generating test data in MongoDB",
@@ -13,6 +13,6 @@ setuptools.setup(
     long_description="Monufacture is a factory framework with an API designed to make " +
                      "it as easy as possible to generate valid test data in MongoDB. " +
                      "Inspired by the excellent factory_girl Ruby Gem.",
-    install_requires=['pymongo<3.0.0', 'pytz'],
+    install_requires=['pymongo>=3.0.0', 'pytz'],
     tests_require=['mock', 'nose', 'freezegun']
 )

--- a/tests/factory_tests.py
+++ b/tests/factory_tests.py
@@ -499,7 +499,7 @@ class TestFactory(unittest.TestCase):
             "first_name": "John",
             "last_name": "Smith",
             "age": 32
-        }, safe=True)
+        })
         self.collection.find_one.assert_called_with(to_return["_id"])
         self.assertDictEqual(created, to_return)
 
@@ -527,7 +527,7 @@ class TestFactory(unittest.TestCase):
             "first_name": "Mike",
             "last_name": "Smith",
             "age": 32
-        }, safe=True)
+        })
         self.collection.find_one.assert_called_with(to_return["_id"])
         self.assertDictEqual(created, to_return)
 
@@ -543,7 +543,7 @@ class TestFactory(unittest.TestCase):
         factory = Factory(self.collection)
         factory.default({})
         factory.create(**scary_overrides)
-        self.collection.insert.assert_called_with(scary_overrides, safe=True)
+        self.collection.insert.assert_called_with(scary_overrides)
 
 
     def test_create_with_additional_fields(self):
@@ -572,7 +572,7 @@ class TestFactory(unittest.TestCase):
             "last_name": "Smith",
             "age": 32,
             "gender": "male"
-        }, safe=True)
+        })
         self.collection.find_one.assert_called_with(to_return["_id"])
         self.assertDictEqual(created, to_return)
 
@@ -639,7 +639,7 @@ class TestFactory(unittest.TestCase):
             "last_name": "Smith",
             "age": 45,
             "gender": "male"
-        }, safe=True)
+        })
         self.collection.find_one.assert_called_with(to_return["_id"])
         self.assertDictEqual(created, to_return)
 
@@ -685,7 +685,7 @@ class TestFactory(unittest.TestCase):
 
         factory.cleanup()
 
-        expected_calls = [call(oid, safe=True) for oid in cleanup_ids]
+        expected_calls = [call(oid) for oid in cleanup_ids]
         self.assertEqual(self.collection.remove.mock_calls, expected_calls)
         self.collection.reset_mock()
         factory.cleanup()

--- a/tests/module_tests.py
+++ b/tests/module_tests.py
@@ -5,11 +5,11 @@ from monufacture import factory, trait, default, document, fragment, embed, buil
 from monufacture.helpers import dependent, sequence, id_of
 from mock import Mock, patch, ANY
 from bson.objectid import ObjectId
-from pymongo.connection import Connection
+from pymongo import MongoClient
 
 host = os.environ.get("DB_IP", "localhost")
 port = int(os.environ.get("DB_PORT", 27017))
-conn = Connection(host, port).monufacture_test
+conn = MongoClient(host, port).monufacture_test
 
 class TestDeclaration(TestCase):
     """Tests for "declaration"-type methods which allow factories to
@@ -31,7 +31,7 @@ class TestDeclaration(TestCase):
             fragment("test", {"a": "b"})
 
 class TestGeneration(TestCase):
-    """Tests for "generation"-type methods - those which create new 
+    """Tests for "generation"-type methods - those which create new
     document instances using registered factories."""
     def setUp(self):
         self.company_id = ObjectId()
@@ -52,7 +52,7 @@ class TestGeneration(TestCase):
 
             fragment("prefs_sms", {
                 "receives_sms": False,
-                "receives_email": True                
+                "receives_email": True
             }, traits=['versioned'])
 
             fragment("empty_prefs", traits=['versioned'])
@@ -81,7 +81,7 @@ class TestGeneration(TestCase):
                 "age": sequence(lambda n: n + 20)
             }, parent="timestamped")
 
-        
+
         with factory("company", self.company_collection):
             default({
                 "name": "GloboCorp"
@@ -177,7 +177,7 @@ class TestGeneration(TestCase):
         self.assertEquals(doc2, expected2)
 
     def test_create(self):
-        
+
         created = create("user", first='Mike')
 
         expected = {
@@ -194,7 +194,7 @@ class TestGeneration(TestCase):
             "created": "now"
         }
 
-        self.assertDictContainsSubset(expected, created)        
+        self.assertDictContainsSubset(expected, created)
 
     def test_create_named_document(self):
         created = create("user", "admin", first='Mike')
@@ -214,7 +214,7 @@ class TestGeneration(TestCase):
             "v": 4
         }
 
-        self.assertDictContainsSubset(expected, created)        
+        self.assertDictContainsSubset(expected, created)
 
     def test_build_list(self):
         expected_list = [{
@@ -394,9 +394,9 @@ class TestGeneration(TestCase):
             "age": 23,
             "created": "now"
         }]
-        
+
         created_docs = create_list(3, "user")
-        
+
         for created, expected in zip(created_docs, expected_docs):
             self.assertDictContainsSubset(expected, created)
 
@@ -441,7 +441,7 @@ class TestGeneration(TestCase):
             "created": "now",
             "v": 4
         }]
-        
+
         created_list = create_list(3, "user", "admin")
 
         for expected, actual in zip(expected_docs, created_list):
@@ -520,7 +520,7 @@ class TestGeneration(TestCase):
 
         def check_log(factory, document=None, **overrides):
             debug.assert_called_once_with(
-                "CREATED [%s]: %s, document=%s, overrides=%s", 
+                "CREATED [%s]: %s, document=%s, overrides=%s",
                 ANY, factory, document, overrides)
             debug.reset_mock()
 
@@ -532,4 +532,3 @@ class TestGeneration(TestCase):
         check_log('company', thing='blah')
         create_list(1, 'company', 'pharma', thing='blah')
         check_log('company', 'pharma', thing='blah')
-

--- a/tests/unittest_tests.py
+++ b/tests/unittest_tests.py
@@ -1,5 +1,5 @@
 import os
-from pymongo.connection import Connection
+from pymongo import MongoClient
 from unittest import TestCase, TestLoader, TestResult
 from monufacture import factory, create, create_list, reset, default
 from monufacture.unittest import enable_factories
@@ -8,7 +8,7 @@ from monufacture.helpers import dependent, sequence, id_of
 host = os.environ.get("DB_IP", "localhost")
 port = int(os.environ.get("DB_PORT", 27017))
 
-conn = Connection(host, port).monufacture_test
+conn = MongoClient(host, port).monufacture_test
 company_collection = conn.company
 user_collection = conn.user
 
@@ -45,7 +45,7 @@ class TestUnittestSupport(TestCase):
                 "email": dependent(lambda doc: "%s.%s@test.com" % (doc['first'], doc['last'])),
                 "age": sequence(lambda n: n + 20)
             })
-        
+
         with factory("company", company_collection):
             default({
                 "name": "GloboCorp"


### PR DESCRIPTION
cc @nrschultz @paetling 

PyMongo 3 is chock full of deprecations, new APIs, and all sorts of other stuff. This PR is doing the minimum possible to get Monufacture 2.0 into a state where it can feasibly operate using PyMongo 3. Further changes will be needed to remove all deprecated features.

This only needed to deal with two breaking changes:
1. The `safe` kwarg was removed across all methods.
2. `Connection` was removed and `MongoClient` has taken its place

[PyMongo 3 Migration Guide](http://api.mongodb.com/python/current/migrate-to-pymongo3.html#mongoclient)